### PR TITLE
US526918 : [MASFoundation][iOS] NSFaceIDUsageDescription is required …

### DIFF
--- a/StorageApp/Info.plist
+++ b/StorageApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSFaceIDUsageDescription</key>
+	<string>The application must access FaceID to unlock the user session with FaceID-enabled devices.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
…to enable FaceID